### PR TITLE
php_flag does not work on Servern with FastCGI or CGI

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -3,7 +3,8 @@
         Options -MultiViews
     </IfModule>
 
-    php_flag opcache.enable Off
+	# This does not work on Servern with FastCGI or CGI
+    #php_flag opcache.enable Off
 
     RewriteEngine On
 


### PR DESCRIPTION
You get 500 Internal Server Error when using .htaccess for PHP Settings, when your Server uses FastCGI or CGI.